### PR TITLE
Fix for apps with spaces in path

### DIFF
--- a/lib/crash_monkey/monkey_runner.rb
+++ b/lib/crash_monkey/monkey_runner.rb
@@ -165,7 +165,7 @@ module UIAutoMonkey
     end
 
     def find_apps(app)
-      `find #{ENV['HOME']}/Library/Developer/Xcode/DerivedData -name '#{app}'`.strip.split(/\n/)
+      `"ls" -dt #{ENV['HOME']}/Library/Developer/Xcode/DerivedData/*/Build/Products/*/'#{app}'`.strip.split(/\n/)
     end
 
     def devices

--- a/lib/crash_monkey/monkey_runner.rb
+++ b/lib/crash_monkey/monkey_runner.rb
@@ -220,7 +220,7 @@ module UIAutoMonkey
     end
 
     def crash_report_list
-      `ls -t '#{crash_report_dir}/#{app_name}_*.crash'`.strip.split(/\n/)
+      `ls -t #{crash_report_dir}/'#{app_name}'_*.crash`.strip.split(/\n/)
     end
 
     def grep_syslog

--- a/lib/crash_monkey/monkey_runner.rb
+++ b/lib/crash_monkey/monkey_runner.rb
@@ -165,7 +165,7 @@ module UIAutoMonkey
     end
 
     def find_apps(app)
-      `"ls" -dt #{ENV['HOME']}/Library/Developer/Xcode/DerivedData/*/Build/Products/*/#{app}`.strip.split(/\n/)
+      `find #{ENV['HOME']}/Library/Developer/Xcode/DerivedData -name '#{app}'`.strip.split(/\n/)
     end
 
     def devices
@@ -220,7 +220,7 @@ module UIAutoMonkey
     end
 
     def crash_report_list
-      `ls -t #{crash_report_dir}/#{app_name}_*.crash`.strip.split(/\n/)
+      `ls -t '#{crash_report_dir}/#{app_name}_*.crash'`.strip.split(/\n/)
     end
 
     def grep_syslog

--- a/lib/crash_monkey/templates/config.json
+++ b/lib/crash_monkey/templates/config.json
@@ -10,7 +10,7 @@
         "orientation": 1,
         "clickVolumeUp": 1,
         "clickVolumeDown": 1,
-        "lock": 3,
+        "lock": 0,
         "pinchClose": 50,
         "pinchOpen": 50,
         "shake": 1,


### PR DESCRIPTION
When the filename had a space in the path, it would not be able to find the correct folder in the DerivedData folder and it would also not find the right crash reports. This merge request should fix that.