### PR TITLE
Issue #17: Don't crash when deactivate event is triggered

### DIFF
--- a/lib/ui-auto-monkey/UIAutoMonkey.js
+++ b/lib/ui-auto-monkey/UIAutoMonkey.js
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2013 Jonathan Penn (http://cocoamanifest.net/)
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -45,7 +46,8 @@ function UIAutoMonkey() {
 			lock: 0,
 			pinchClose: 10,
 			pinchOpen: 10,
-			shake: 1
+			shake: 1,
+			deactivate: 0
 		},
 
 		// Probability that touch events will have these different properties
@@ -153,7 +155,11 @@ UIAutoMonkey.prototype.allEvents = {
 
 	shake: function() {
 		this.target().shake();
-	}
+	},
+
+    deactivate: function() {
+        this.target().deactivateAppForDuration(Math.random() * 3);
+    }
 };
 
 // --- --- --- ---
@@ -176,6 +182,10 @@ UIAutoMonkey.prototype.triggerRandomEvent = function() {
 	var name = this.chooseEventName();
 	// Find the event method based on the name of the event
 	var event = this.allEvents[name];
+	if (!event) {
+		UIALogger.logMessage("Attempted to " + name)
+		throw new Error("Attempted to fire an undefined event '" + name + "'!")
+	}
 	event.apply(this);
 };
 


### PR DESCRIPTION
Instead, trigger the deactivateAppForDuration() event.